### PR TITLE
Fix  timer minutes & seconds calculation bug when writing to socket

### DIFF
--- a/pomod.c
+++ b/pomod.c
@@ -181,16 +181,16 @@ info(int fd, struct timespec *stoptime, char cycle)
 	buf[MIN] = buf[SEC] = 0;
 	switch (cycle) {
 	case POMODORO:
-		buf[MIN] = (uint8_t)(pomodoro.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(pomodoro.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((pomodoro.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((pomodoro.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	case SHORTBREAK:
-		buf[MIN] = (uint8_t)(shortbreak.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(shortbreak.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((shortbreak.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((shortbreak.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	case LONGBREAK:
-		buf[MIN] = (uint8_t)(longbreak.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(longbreak.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((longbreak.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((longbreak.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	}
 	write(fd, buf, INFOSIZ);

--- a/pomod.c
+++ b/pomod.c
@@ -262,38 +262,32 @@ run(int sd)
 		case POMODORO:
 			if (timespeccmp(&now, &stoptime, >=)) {
 				pomocount++;
+				gettimespec(&stoptime);
 				if (pomocount < 4) {
 					notify(cycle = SHORTBREAK);
 					stoptime.tv_sec += shortbreak.tv_sec;
-					timeout = gettimeout(&stoptime);
 				} else {
 					pomocount = 0;
 					notify(cycle = LONGBREAK);
 					stoptime.tv_sec += longbreak.tv_sec;
-					timeout = gettimeout(&stoptime);
 				}
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		case SHORTBREAK:
 			if (timespeccmp(&now, &stoptime, >)) {
 				notify(cycle = POMODORO);
 				stoptime.tv_sec += pomodoro.tv_sec;
-				timeout = gettimeout(&stoptime);
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		case LONGBREAK:
 			pomocount = 0;
 			if (timespeccmp(&now, &stoptime, >)) {
 				notify(cycle = POMODORO);
 				stoptime.tv_sec += pomodoro.tv_sec;
-				timeout = gettimeout(&stoptime);
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		}
 	}


### PR DESCRIPTION
This resolves the bug reported in issue #1 by ensuring that `pomod.c`'s `info()` doesn't cast minutes/seconds calculations to `uint8_t` until after division/modulus has been performed. The current implementation is written in such a way that the casting to `uint8_t` is only performed on the portion of the minutes/seconds calculations for the elapsed seconds, limiting the number of seconds calculated to no more than 255.