### PR TITLE
Fix too many open files crash in `pomod` due to file descriptors not being closed when `pomo` clients disconnect

### DIFF
--- a/pomod.c
+++ b/pomod.c
@@ -181,16 +181,16 @@ info(int fd, struct timespec *stoptime, char cycle)
 	buf[MIN] = buf[SEC] = 0;
 	switch (cycle) {
 	case POMODORO:
-		buf[MIN] = (uint8_t)(pomodoro.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(pomodoro.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((pomodoro.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((pomodoro.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	case SHORTBREAK:
-		buf[MIN] = (uint8_t)(shortbreak.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(shortbreak.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((shortbreak.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((shortbreak.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	case LONGBREAK:
-		buf[MIN] = (uint8_t)(longbreak.tv_sec - diff.tv_sec) / SECONDS;
-		buf[SEC] = (uint8_t)(longbreak.tv_sec - diff.tv_sec) % SECONDS;
+		buf[MIN] = (uint8_t)((longbreak.tv_sec - diff.tv_sec) / SECONDS);
+		buf[SEC] = (uint8_t)((longbreak.tv_sec - diff.tv_sec) % SECONDS);
 		break;
 	}
 	write(fd, buf, INFOSIZ);

--- a/pomod.c
+++ b/pomod.c
@@ -262,38 +262,32 @@ run(int sd)
 		case POMODORO:
 			if (timespeccmp(&now, &stoptime, >=)) {
 				pomocount++;
+				gettimespec(&stoptime);
 				if (pomocount < 4) {
 					notify(cycle = SHORTBREAK);
 					stoptime.tv_sec += shortbreak.tv_sec;
-					timeout = gettimeout(&stoptime);
 				} else {
 					pomocount = 0;
 					notify(cycle = LONGBREAK);
 					stoptime.tv_sec += longbreak.tv_sec;
-					timeout = gettimeout(&stoptime);
 				}
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		case SHORTBREAK:
 			if (timespeccmp(&now, &stoptime, >)) {
 				notify(cycle = POMODORO);
 				stoptime.tv_sec += pomodoro.tv_sec;
-				timeout = gettimeout(&stoptime);
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		case LONGBREAK:
 			pomocount = 0;
 			if (timespeccmp(&now, &stoptime, >)) {
 				notify(cycle = POMODORO);
 				stoptime.tv_sec += pomodoro.tv_sec;
-				timeout = gettimeout(&stoptime);
-			} else {
-				timeout = gettimeout(&stoptime);
 			}
+			timeout = gettimeout(&stoptime);
 			break;
 		}
 	}


### PR DESCRIPTION
This fixes the eventual crashes of `pomod` due to "too many open files". This is especially problematic when executing `pomo info` once per second, as my morgant/xpomodmenu project does.

The fix provided here updates `run()` in `pomod.c` to `close()` the per-client file descriptor if [`poll()`](http://man.openbsd.org/poll) indicates that the client has disconnected. It also adds a warning to `stderr` if too many clients attempt to connect.

**NOTE**: This PR is applied on top of my previous PR #2 (for issue #1). That should be merged before this PR.